### PR TITLE
Multisite support

### DIFF
--- a/src/Codeception/Module/DrupalBootstrap.php
+++ b/src/Codeception/Module/DrupalBootstrap.php
@@ -45,6 +45,9 @@ class DrupalBootstrap extends Module {
     $_SERVER['PHP_SELF'] = $_SERVER['REQUEST_URI'] . 'index.php';
     $_SERVER['SCRIPT_NAME'] = $_SERVER['PHP_SELF'];
     $_SERVER['SCRIPT_FILENAME'] = $this->config['drupal_root'] . '/index.php';
+    if (isset($this->config['http_host'])) {
+      $_SERVER['HTTP_HOST'] = $this->config['http_host'];
+    }
     $request = Request::createFromGlobals();
     $autoloader = require $this->config['drupal_root'] . '/autoload.php';
     $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod');


### PR DESCRIPTION
The HTTP_HOST header must be set for the tests to work in multisite environment.
The suites need to be set up per site.